### PR TITLE
Add the ability to solve a specific sudoku without needing to create a file to load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,10 @@ struct Config {
     #[clap(short, long)]
     quiet: bool,
 
+    /// Load Sudoku by unique ID
+    #[clap(short, long)]
+    uid: Option<String>,
+
     /// Load Sudoku from file
     #[clap(short, long)]
     file: Option<String>,
@@ -23,9 +27,14 @@ fn main() {
 
     let sudoku = match &config.file {
         Some(file) => Sudoku::from_str(&fs::read_to_string(file).unwrap()),
-        _ => Sudoku::from_str(
-            "xxxxxxx9xx9x7xx21xxx4x9xxxxx1xxx8xxx7xx42xxx5xx8xxxx748x1xxxx4xxxxxxxxxxxx9613xxx",
-        ),
+        _ => {
+            match &config.uid {
+                Some(uid) => Sudoku::from_str(uid),
+                _ => Sudoku::from_str(
+                    "xxxxxxx9xx9x7xx21xxx4x9xxxxx1xxx8xxx7xx42xxx5xx8xxxx748x1xxxx4xxxxxxxxxxxx9613xxx",
+                ),
+            }
+        },
     };
 
     println!(


### PR DESCRIPTION
Title ^

Added a command line argument `-u` or `--uid` (for unique ID, wasn't sure on the name though!) to load a specific sudoku by String through the command line. 

Perhaps would be worth making this more safe with some kind of check that the sudoku is valid etc etc.